### PR TITLE
Make index in enumerate start from 1

### DIFF
--- a/src/pyradio_nepal/main.py
+++ b/src/pyradio_nepal/main.py
@@ -26,8 +26,8 @@ def pretty_print_stations():
     datas = [['S.N.', 'NAME', 'LOCATION', 'FREQUENCY']]
     with open(file_path, 'r') as f:
         stations_json = json.loads(f.read())
-        for counter, station in enumerate(stations_json):
-            datas.append([counter + 1, station['name'], station['location'], station['frequency']])
+        for counter, station in enumerate(stations_json, start = 1):
+            datas.append([counter, station['name'], station['location'], station['frequency']])
     print(AsciiTable(datas).table)
 
 # start the player


### PR DESCRIPTION
The start parameter can be passed to enumerate( ) function to start the index from 1 rather than 0. This can be cleaner than using counter + 1.
